### PR TITLE
feat(infra): Flyway migrations + demo seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The project follows the **Controller-Service-Repository** pattern to ensure sepa
 * **Config:** Security filter chain, JWT filter, and authentication provider setup.
 * **Handlers:** Global Exception Handling for standardized API error responses.
 
+## 🔒 Data Isolation (Multi-Tenancy per User)
+
+All resources are scoped to the authenticated user. `Category` and `Transaction` entities carry a `user_id` FK. Every repository query filters by the authenticated principal — users can only read and modify their own data. Attempting to access a resource owned by another user returns `404` to avoid leaking resource existence.
+
 ## 🐳 Getting Started (Docker)
 
 To run the database and the management tools (PgAdmin) locally:
@@ -92,7 +96,7 @@ The API uses **stateless JWT authentication**. All endpoints except `/api/v1/aut
 
 ### 🔒 V2 — Security & Multi-Tenancy
 - [x] **Issue #14:** User entity + Spring Security + JWT Authentication + Refresh Token.
-- [ ] **Issue #15:** Data isolation — Category and Transaction linked to authenticated User.
+- [x] **Issue #15:** Data isolation — Category and Transaction linked to authenticated User.
 
 ### 🔧 V3 — Resilience & Observability
 - [ ] **Issue #16:** Database Migrations with Flyway.

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,16 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/dustin/fintrack/controller/v1/CategoryController.java
+++ b/src/main/java/com/dustin/fintrack/controller/v1/CategoryController.java
@@ -2,10 +2,12 @@ package com.dustin.fintrack.controller.v1;
 
 import com.dustin.fintrack.dto.v1.request.CategoryRequestDTO;
 import com.dustin.fintrack.dto.v1.response.CategoryResponseDTO;
+import com.dustin.fintrack.model.User;
 import com.dustin.fintrack.service.CategoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,33 +20,33 @@ public class CategoryController {
     private final CategoryService categoryService;
 
     @PostMapping
-    public ResponseEntity<CategoryResponseDTO> create(@RequestBody CategoryRequestDTO category) {
-        CategoryResponseDTO createdCategory = categoryService.create(category);
-        return new ResponseEntity<>(createdCategory, HttpStatus.CREATED);
+    public ResponseEntity<CategoryResponseDTO> create(
+            @RequestBody CategoryRequestDTO category,
+            @AuthenticationPrincipal User user) {
+        return new ResponseEntity<>(categoryService.create(category, user), HttpStatus.CREATED);
     }
 
     @GetMapping
-    public ResponseEntity<List<CategoryResponseDTO>> listAll() {
-        List<CategoryResponseDTO> categories = categoryService.listAll();
-        return ResponseEntity.ok(categories);
+    public ResponseEntity<List<CategoryResponseDTO>> listAll(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(categoryService.listAll(user));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<CategoryResponseDTO> update(@PathVariable Long id, @RequestBody CategoryRequestDTO dto) {
-        CategoryResponseDTO updatedCategory = categoryService.update(id, dto);
-        return ResponseEntity.ok(updatedCategory);
+    public ResponseEntity<CategoryResponseDTO> update(
+            @PathVariable Long id,
+            @RequestBody CategoryRequestDTO dto,
+            @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(categoryService.update(id, dto, user));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
-        categoryService.delete(id);
+    public ResponseEntity<Void> delete(@PathVariable Long id, @AuthenticationPrincipal User user) {
+        categoryService.delete(id, user);
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<CategoryResponseDTO> findById(@PathVariable Long id) {
-        CategoryResponseDTO category = categoryService.findById(id);
-
-        return ResponseEntity.ok(category);
+    public ResponseEntity<CategoryResponseDTO> findById(@PathVariable Long id, @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(categoryService.findById(id, user));
     }
 }

--- a/src/main/java/com/dustin/fintrack/controller/v1/TransactionController.java
+++ b/src/main/java/com/dustin/fintrack/controller/v1/TransactionController.java
@@ -3,12 +3,14 @@ package com.dustin.fintrack.controller.v1;
 import com.dustin.fintrack.dto.v1.request.TransactionRequestDTO;
 import com.dustin.fintrack.dto.v1.response.DashboardResponseDTO;
 import com.dustin.fintrack.dto.v1.response.TransactionResponseDTO;
+import com.dustin.fintrack.model.User;
 import com.dustin.fintrack.service.TransactionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -22,45 +24,41 @@ public class TransactionController {
     private final TransactionService transactionService;
 
     @PostMapping
-    public ResponseEntity<TransactionResponseDTO> create(@Valid @RequestBody TransactionRequestDTO request) {
-        TransactionResponseDTO response = transactionService.create(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    public ResponseEntity<TransactionResponseDTO> create(
+            @Valid @RequestBody TransactionRequestDTO request,
+            @AuthenticationPrincipal User user) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(transactionService.create(request, user));
     }
 
     @GetMapping
-    public ResponseEntity<List<TransactionResponseDTO>> listAll() {
-        List<TransactionResponseDTO> transactions = transactionService.listAll();
-        return ResponseEntity.ok(transactions);
+    public ResponseEntity<List<TransactionResponseDTO>> listAll(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(transactionService.listAll(user));
     }
 
     @GetMapping("/dashboard")
     public ResponseEntity<DashboardResponseDTO> getDashboard(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end) {
-
-        DashboardResponseDTO dashboardData = transactionService.getDashboardData(start, end);
-
-        return ResponseEntity.ok(dashboardData);
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(transactionService.getDashboardData(start, end, user));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<TransactionResponseDTO> findById(@PathVariable Long id) {
-        TransactionResponseDTO transaction = transactionService.findById(id);
-        return ResponseEntity.ok(transaction);
+    public ResponseEntity<TransactionResponseDTO> findById(@PathVariable Long id, @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(transactionService.findById(id, user));
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<TransactionResponseDTO> update(
             @PathVariable Long id,
-            @Valid @RequestBody TransactionRequestDTO request) {
-        TransactionResponseDTO response = transactionService.update(id, request);
-
-        return ResponseEntity.ok(response);
+            @Valid @RequestBody TransactionRequestDTO request,
+            @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(transactionService.update(id, request, user));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
-        transactionService.delete(id);
+    public ResponseEntity<Void> delete(@PathVariable Long id, @AuthenticationPrincipal User user) {
+        transactionService.delete(id, user);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/dustin/fintrack/model/Category.java
+++ b/src/main/java/com/dustin/fintrack/model/Category.java
@@ -6,7 +6,9 @@ import lombok.*;
 import java.math.BigDecimal;
 
 @Entity
-@Table(name = "categories")
+@Table(name = "categories", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"name", "user_id"})
+})
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -16,9 +18,13 @@ public class Category {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String name;
     private String color;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/dustin/fintrack/model/Transaction.java
+++ b/src/main/java/com/dustin/fintrack/model/Transaction.java
@@ -33,6 +33,10 @@ public class Transaction {
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
     @Column
     private Integer dueDay;
 

--- a/src/main/java/com/dustin/fintrack/repository/CategoryRepository.java
+++ b/src/main/java/com/dustin/fintrack/repository/CategoryRepository.java
@@ -1,9 +1,17 @@
 package com.dustin.fintrack.repository;
 
 import com.dustin.fintrack.model.Category;
+import com.dustin.fintrack.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    List<Category> findAllByUser(User user);
+
+    Optional<Category> findByIdAndUser(Long id, User user);
 }

--- a/src/main/java/com/dustin/fintrack/repository/TransactionRepository.java
+++ b/src/main/java/com/dustin/fintrack/repository/TransactionRepository.java
@@ -1,6 +1,7 @@
 package com.dustin.fintrack.repository;
 
 import com.dustin.fintrack.model.Transaction;
+import com.dustin.fintrack.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -8,14 +9,19 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TransactionRepository extends JpaRepository<Transaction, Long> {
-    @Query("SELECT t FROM Transaction t WHERE t.date BETWEEN :startDate AND :endDate ORDER BY t.date DESC")
-    List<Transaction> findByDateRange(
+
+    List<Transaction> findAllByUser(User user);
+
+    Optional<Transaction> findByIdAndUser(Long id, User user);
+
+    @Query("SELECT t FROM Transaction t WHERE t.user = :user AND t.date BETWEEN :startDate AND :endDate ORDER BY t.date DESC")
+    List<Transaction> findByUserAndDateRange(
+            @Param("user") User user,
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate
     );
-
-    List<Transaction> findByCategoryId(Long categoryId);
 }

--- a/src/main/java/com/dustin/fintrack/service/CategoryService.java
+++ b/src/main/java/com/dustin/fintrack/service/CategoryService.java
@@ -4,6 +4,7 @@ import com.dustin.fintrack.controller.exception.ResourceNotFoundException;
 import com.dustin.fintrack.dto.v1.request.CategoryRequestDTO;
 import com.dustin.fintrack.dto.v1.response.CategoryResponseDTO;
 import com.dustin.fintrack.model.Category;
+import com.dustin.fintrack.model.User;
 import com.dustin.fintrack.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,13 +20,14 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
 
     @Transactional
-    public CategoryResponseDTO create(CategoryRequestDTO request) {
+    public CategoryResponseDTO create(CategoryRequestDTO request, User user) {
         Category category = new Category();
         category.setName(request.getName());
         category.setColor(request.getColor());
         category.setDescription(request.getDescription());
         category.setCategoryType(request.getCategoryType());
         category.setSpendingLimit(request.getSpendingLimit());
+        category.setUser(user);
 
         Category savedCategory = categoryRepository.save(category);
 
@@ -33,15 +35,16 @@ public class CategoryService {
     }
 
     @Transactional(readOnly = true)
-    public List<CategoryResponseDTO> listAll() {
-        return categoryRepository.findAll()
+    public List<CategoryResponseDTO> listAll(User user) {
+        return categoryRepository.findAllByUser(user)
                 .stream()
                 .map(CategoryResponseDTO::new)
                 .toList();
     }
 
-    public CategoryResponseDTO update(Long id, CategoryRequestDTO dto) {
-        Category existingCategory = categoryRepository.findById(id)
+    @Transactional
+    public CategoryResponseDTO update(Long id, CategoryRequestDTO dto, User user) {
+        Category existingCategory = categoryRepository.findByIdAndUser(id, user)
                 .orElseThrow(() -> new ResourceNotFoundException("Category not found with id: " + id));
 
         Optional.ofNullable(dto.getName()).ifPresent(existingCategory::setName);
@@ -53,16 +56,17 @@ public class CategoryService {
         return new CategoryResponseDTO(categoryRepository.save(existingCategory));
     }
 
-    public void delete(Long id) {
-        Category existingCategory = categoryRepository.findById(id)
+    @Transactional
+    public void delete(Long id, User user) {
+        Category existingCategory = categoryRepository.findByIdAndUser(id, user)
                 .orElseThrow(() -> new ResourceNotFoundException("Category not found with id: " + id));
 
         categoryRepository.deleteById(existingCategory.getId());
     }
 
     @Transactional(readOnly = true)
-    public CategoryResponseDTO findById(Long id) {
-        Category category = categoryRepository.findById(id)
+    public CategoryResponseDTO findById(Long id, User user) {
+        Category category = categoryRepository.findByIdAndUser(id, user)
             .orElseThrow(() -> new ResourceNotFoundException("Category not found with id: " + id));
 
         return new CategoryResponseDTO(category);

--- a/src/main/java/com/dustin/fintrack/service/TransactionService.java
+++ b/src/main/java/com/dustin/fintrack/service/TransactionService.java
@@ -4,6 +4,7 @@ import com.dustin.fintrack.controller.exception.ResourceNotFoundException;
 import com.dustin.fintrack.dto.v1.request.TransactionRequestDTO;
 import com.dustin.fintrack.model.Category;
 import com.dustin.fintrack.model.Transaction;
+import com.dustin.fintrack.model.User;
 import com.dustin.fintrack.repository.TransactionRepository;
 import com.dustin.fintrack.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.math.BigDecimal;
-import  java.time.LocalDateTime;
+import java.time.LocalDateTime;
 
 import com.dustin.fintrack.dto.v1.response.TransactionResponseDTO;
 
@@ -28,10 +29,9 @@ public class TransactionService {
     private final CategoryRepository categoryRepository;
 
     @Transactional
-    public TransactionResponseDTO create(TransactionRequestDTO request) {
-
-        Category category = categoryRepository.findById(request.getCategoryId())
-                .orElseThrow(() -> new ResourceNotFoundException(request.getCategoryId()));
+    public TransactionResponseDTO create(TransactionRequestDTO request, User user) {
+        Category category = categoryRepository.findByIdAndUser(request.getCategoryId(), user)
+                .orElseThrow(() -> new ResourceNotFoundException("Category not found with id: " + request.getCategoryId()));
 
         Transaction transaction = new Transaction();
         transaction.setDescription(request.getDescription());
@@ -39,24 +39,24 @@ public class TransactionService {
         transaction.setDate(request.getDate());
         transaction.setType(request.getType());
         transaction.setCategory(category);
+        transaction.setUser(user);
         transaction.setDueDay(request.getDueDay());
         transaction.setIsPaid(request.getIsPaid() != null ? request.getIsPaid() : false);
-        Transaction savedTransaction = transactionRepository.save(transaction);
 
-        return new TransactionResponseDTO(savedTransaction);
+        return new TransactionResponseDTO(transactionRepository.save(transaction));
     }
 
     @Transactional(readOnly = true)
-    public List<TransactionResponseDTO> listAll() {
-        return transactionRepository.findAll()
+    public List<TransactionResponseDTO> listAll(User user) {
+        return transactionRepository.findAllByUser(user)
                 .stream()
                 .map(TransactionResponseDTO::new)
                 .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
-    public DashboardResponseDTO getDashboardData(LocalDateTime start, LocalDateTime end) {
-        List<Transaction> transactions = transactionRepository.findByDateRange(start, end);
+    public DashboardResponseDTO getDashboardData(LocalDateTime start, LocalDateTime end, User user) {
+        List<Transaction> transactions = transactionRepository.findByUserAndDateRange(user, start, end);
 
         BigDecimal totalIncome = transactions.stream()
                 .filter(t -> t.getType() == TransactionType.INCOME)
@@ -78,16 +78,16 @@ public class TransactionService {
     }
 
     @Transactional(readOnly = true)
-    public TransactionResponseDTO findById(Long id) {
-        Transaction transaction = transactionRepository.findById(id)
+    public TransactionResponseDTO findById(Long id, User user) {
+        Transaction transaction = transactionRepository.findByIdAndUser(id, user)
                 .orElseThrow(() -> new ResourceNotFoundException("Transaction not found with id: " + id));
 
         return new TransactionResponseDTO(transaction);
     }
 
     @Transactional
-    public TransactionResponseDTO update(Long id, TransactionRequestDTO request) {
-        Transaction existingTransaction = transactionRepository.findById(id)
+    public TransactionResponseDTO update(Long id, TransactionRequestDTO request, User user) {
+        Transaction existingTransaction = transactionRepository.findByIdAndUser(id, user)
                 .orElseThrow(() -> new ResourceNotFoundException("Transaction not found with id: " + id));
 
         Optional.ofNullable(request.getDescription()).ifPresent(existingTransaction::setDescription);
@@ -97,7 +97,7 @@ public class TransactionService {
         Optional.ofNullable(request.getDueDay()).ifPresent(existingTransaction::setDueDay);
         Optional.ofNullable(request.getIsPaid()).ifPresent(existingTransaction::setIsPaid);
         Optional.ofNullable(request.getCategoryId()).ifPresent(categoryId -> {
-            Category existingCategory = categoryRepository.findById(categoryId)
+            Category existingCategory = categoryRepository.findByIdAndUser(categoryId, user)
                     .orElseThrow(() -> new ResourceNotFoundException("Category not found with id: " + categoryId));
             existingTransaction.setCategory(existingCategory);
         });
@@ -105,8 +105,9 @@ public class TransactionService {
         return new TransactionResponseDTO(transactionRepository.save(existingTransaction));
     }
 
-    public void delete(Long id) {
-        Transaction existingTransaction = transactionRepository.findById(id)
+    @Transactional
+    public void delete(Long id, User user) {
+        Transaction existingTransaction = transactionRepository.findByIdAndUser(id, user)
                 .orElseThrow(() -> new ResourceNotFoundException("Transaction not found with id: " + id));
 
         transactionRepository.deleteById(existingTransaction.getId());

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -2,9 +2,14 @@
 spring.datasource.url=jdbc:postgresql://localhost:5432/fintrack_db
 spring.datasource.username=Admin
 spring.datasource.password=nimda
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+# Flyway
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+spring.flyway.baseline-on-migrate=true
 jwt.secret=fintrack-dev-secret-key-256bits-minimum
 jwt.expiration=86400000
 jwt.refresh-expiration=604800000

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,10 +1,14 @@
-# Production environment ? valores reais virão de variáveis de ambiente
+# Production environment ? valores reais virï¿½o de variï¿½veis de ambiente
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
-spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=false
+
+# Flyway
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
 jwt.secret=${JWT_SECRET}
 jwt.expiration=86400000
 jwt.refresh-expiration=604800000

--- a/src/main/resources/db/migration/V1__create_users_table.sql
+++ b/src/main/resources/db/migration/V1__create_users_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE users (
+    id         BIGSERIAL    PRIMARY KEY,
+    name       VARCHAR(255) NOT NULL,
+    email      VARCHAR(255) NOT NULL UNIQUE,
+    password   VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP    NOT NULL
+);

--- a/src/main/resources/db/migration/V2__create_categories_table.sql
+++ b/src/main/resources/db/migration/V2__create_categories_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE categories (
+    id             BIGSERIAL    PRIMARY KEY,
+    name           VARCHAR(255) NOT NULL UNIQUE,
+    color          VARCHAR(255),
+    category_type  VARCHAR(50)  NOT NULL,
+    description    VARCHAR(255),
+    spending_limit NUMERIC(19, 2)
+);

--- a/src/main/resources/db/migration/V3__create_transactions_table.sql
+++ b/src/main/resources/db/migration/V3__create_transactions_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE transactions (
+    id          BIGSERIAL      PRIMARY KEY,
+    description VARCHAR(255)   NOT NULL,
+    amount      NUMERIC(19, 2) NOT NULL,
+    date        TIMESTAMP      NOT NULL,
+    type        VARCHAR(50)    NOT NULL,
+    category_id BIGINT         NOT NULL REFERENCES categories (id),
+    due_day     INTEGER,
+    is_paid     BOOLEAN        NOT NULL DEFAULT FALSE
+);

--- a/src/main/resources/db/migration/V4__create_refresh_tokens_table.sql
+++ b/src/main/resources/db/migration/V4__create_refresh_tokens_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE refresh_tokens (
+    id          BIGSERIAL    PRIMARY KEY,
+    token       VARCHAR(255) NOT NULL UNIQUE,
+    user_id     BIGINT       NOT NULL REFERENCES users (id),
+    expiry_date TIMESTAMP    NOT NULL
+);

--- a/src/main/resources/db/migration/V5__add_user_id_to_categories_and_transactions.sql
+++ b/src/main/resources/db/migration/V5__add_user_id_to_categories_and_transactions.sql
@@ -1,0 +1,13 @@
+-- Add user ownership to categories (issue #15 — data isolation)
+ALTER TABLE categories
+    ADD COLUMN user_id BIGINT NOT NULL REFERENCES users (id);
+
+ALTER TABLE categories
+    DROP CONSTRAINT IF EXISTS categories_name_key;
+
+ALTER TABLE categories
+    ADD CONSTRAINT uk_category_name_user UNIQUE (name, user_id);
+
+-- Add user ownership to transactions (issue #15 — data isolation)
+ALTER TABLE transactions
+    ADD COLUMN user_id BIGINT NOT NULL REFERENCES users (id);

--- a/src/main/resources/db/migration/V6__seed_demo_user_and_categories.sql
+++ b/src/main/resources/db/migration/V6__seed_demo_user_and_categories.sql
@@ -1,0 +1,37 @@
+-- Demo user (password: #Dustin88)
+INSERT INTO users (name, email, password, created_at)
+VALUES ('Dustin Cordeiro',
+        'cordeiro.dustin00@gmail.com',
+        '$2a$10$yocWVaUTZD5OsYp9x2PypemnVAR2/KNlXYLyY.X/ZdT34vYuSvLAG',
+        NOW());
+
+-- Essential categories
+INSERT INTO categories (name, category_type, spending_limit, user_id)
+SELECT cat.name, cat.category_type::VARCHAR, cat.spending_limit, u.id
+FROM (VALUES
+    ('Aluguel',    'ESSENTIAL', 450000.00),
+    ('Energia',    'ESSENTIAL',  40000.00),
+    ('Água E',     'ESSENTIAL',  12000.00),
+    ('Celular',    'ESSENTIAL',  10000.00),
+    ('Comunes',    'ESSENTIAL',  20000.00),
+    ('Mercado',    'ESSENTIAL', 300000.00),
+    ('Saúde',      'ESSENTIAL',      0.00),
+    ('Transporte', 'ESSENTIAL',  20000.00),
+    ('Água C',     'ESSENTIAL',  30500.00)
+) AS cat(name, category_type, spending_limit)
+CROSS JOIN (SELECT id FROM users WHERE email = 'cordeiro.dustin00@gmail.com') u;
+
+-- Discretionary categories
+INSERT INTO categories (name, category_type, spending_limit, user_id)
+SELECT cat.name, cat.category_type::VARCHAR, cat.spending_limit, u.id
+FROM (VALUES
+    ('Academia',   'DISCRETIONARY',  55800.00),
+    ('Refeições',  'DISCRETIONARY', 100000.00),
+    ('Suplementos','DISCRETIONARY', 100000.00),
+    ('Casa',       'DISCRETIONARY', 100000.00),
+    ('Bodega',     'DISCRETIONARY',  30000.00),
+    ('Cosmetico',  'DISCRETIONARY',  20000.00),
+    ('Roupas',     'DISCRETIONARY',  60000.00),
+    ('Lavanderia', 'DISCRETIONARY',  17000.00)
+) AS cat(name, category_type, spending_limit)
+CROSS JOIN (SELECT id FROM users WHERE email = 'cordeiro.dustin00@gmail.com') u;

--- a/src/test/java/com/dustin/fintrack/controller/v1/CategoryControllerTest.java
+++ b/src/test/java/com/dustin/fintrack/controller/v1/CategoryControllerTest.java
@@ -5,16 +5,17 @@ import com.dustin.fintrack.controller.exception.ResourceNotFoundException;
 import com.dustin.fintrack.dto.v1.request.CategoryRequestDTO;
 import com.dustin.fintrack.dto.v1.response.CategoryResponseDTO;
 import com.dustin.fintrack.model.CategoryType;
+import com.dustin.fintrack.model.User;
 import com.dustin.fintrack.service.CategoryService;
 import com.dustin.fintrack.service.JwtService;
 import com.dustin.fintrack.service.UserDetailsServiceImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -26,11 +27,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WithMockUser
 @WebMvcTest(CategoryController.class)
 @ContextConfiguration(classes = FintrackProApiApplication.class)
 class CategoryControllerTest {
@@ -50,10 +51,20 @@ class CategoryControllerTest {
     @MockitoBean
     private UserDetailsServiceImpl userDetailsService;
 
+    private User mockUser;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = new User();
+        mockUser.setId(1L);
+        mockUser.setEmail("test@test.com");
+        mockUser.setName("Test User");
+        mockUser.setPassword("password");
+    }
+
     @Test
     @DisplayName("POST /api/v1/categories should return 201 Created")
     void createShouldReturn201() throws Exception {
-        // Arrange
         CategoryRequestDTO request = new CategoryRequestDTO();
         request.setName("Electronics");
         request.setColor("#000000");
@@ -62,11 +73,11 @@ class CategoryControllerTest {
 
         CategoryResponseDTO response = new CategoryResponseDTO(1L, "Electronics", "#000000", null, CategoryType.ESSENTIAL, new BigDecimal("300000"));
 
-        when(categoryService.create(any(CategoryRequestDTO.class))).thenReturn(response);
+        when(categoryService.create(any(CategoryRequestDTO.class), any(User.class))).thenReturn(response);
 
-        // Act & Assert
         mockMvc.perform(post("/api/v1/categories")
                         .with(csrf())
+                        .with(user(mockUser))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -77,12 +88,11 @@ class CategoryControllerTest {
     @Test
     @DisplayName("GET /api/v1/categories should return 200 OK with list")
     void listAllShouldReturn200() throws Exception {
-        // Arrange
         CategoryResponseDTO response = new CategoryResponseDTO(1L, "Electronics", "#000000", null, CategoryType.ESSENTIAL, new BigDecimal("300000"));
-        when(categoryService.listAll()).thenReturn(List.of(response));
+        when(categoryService.listAll(any(User.class))).thenReturn(List.of(response));
 
-        // Act & Assert
-        mockMvc.perform(get("/api/v1/categories"))
+        mockMvc.perform(get("/api/v1/categories")
+                        .with(user(mockUser)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.size()").value(1))
                 .andExpect(jsonPath("$[0].name").value("Electronics"));
@@ -91,7 +101,6 @@ class CategoryControllerTest {
     @Test
     @DisplayName("PUT /api/v1/categories/{id} should return 200 OK when category is updated")
     void updateShouldReturn200() throws Exception {
-        // Arrange
         CategoryRequestDTO request = new CategoryRequestDTO();
         request.setName("Lazer");
         request.setColor("#000");
@@ -99,11 +108,11 @@ class CategoryControllerTest {
         request.setSpendingLimit(new BigDecimal("300000"));
 
         CategoryResponseDTO response = new CategoryResponseDTO(1L, "Lazer", "#000", null, CategoryType.DISCRETIONARY, new BigDecimal("300000"));
-        when(categoryService.update(eq(1L), any(CategoryRequestDTO.class))).thenReturn(response);
+        when(categoryService.update(eq(1L), any(CategoryRequestDTO.class), any(User.class))).thenReturn(response);
 
-        // Act & Assert
         mockMvc.perform(put("/api/v1/categories/{id}", 1L)
                         .with(csrf())
+                        .with(user(mockUser))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -114,16 +123,15 @@ class CategoryControllerTest {
     @Test
     @DisplayName("PUT /api/v1/categories/{id} should return 404 when category does not exist")
     void updateShouldReturn404() throws Exception {
-        // Arrange
         CategoryRequestDTO request = new CategoryRequestDTO();
         request.setName("Erro");
 
-        when(categoryService.update(eq(99L), any(CategoryRequestDTO.class)))
+        when(categoryService.update(eq(99L), any(CategoryRequestDTO.class), any(User.class)))
                 .thenThrow(new ResourceNotFoundException("Category not found with id: 99"));
 
-        // Act & Assert
         mockMvc.perform(put("/api/v1/categories/{id}", 99L)
                         .with(csrf())
+                        .with(user(mockUser))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound());
@@ -132,37 +140,34 @@ class CategoryControllerTest {
     @Test
     @DisplayName("DELETE /api/v1/categories/{id} should return 204 No Content")
     void deleteShouldReturn204() throws Exception {
-        // Arrange
-        doNothing().when(categoryService).delete(1L);
+        doNothing().when(categoryService).delete(1L, mockUser);
 
-        // Act & Assert
         mockMvc.perform(delete("/api/v1/categories/{id}", 1L)
-                        .with(csrf()))
+                        .with(csrf())
+                        .with(user(mockUser)))
                 .andExpect(status().isNoContent());
     }
 
     @Test
     @DisplayName("DELETE /api/v1/categories/{id} should return 404 when category does not exist")
     void deleteShouldReturn404() throws Exception {
-        // Arrange
         doThrow(new ResourceNotFoundException("Category not found with id: 99"))
-                .when(categoryService).delete(99L);
+                .when(categoryService).delete(eq(99L), any(User.class));
 
-        // Act & Assert
         mockMvc.perform(delete("/api/v1/categories/{id}", 99L)
-                        .with(csrf()))
+                        .with(csrf())
+                        .with(user(mockUser)))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     @DisplayName("GET /api/v1/categories/{id} should return 200 OK when category exists")
     void findByIdShouldReturn200() throws Exception {
-        // Arrange
         CategoryResponseDTO response = new CategoryResponseDTO(1L, "Electronics", "#000000", null, CategoryType.ESSENTIAL, new BigDecimal("300000"));
-        when(categoryService.findById(1L)).thenReturn(response);
+        when(categoryService.findById(eq(1L), any(User.class))).thenReturn(response);
 
-        // Act & Assert
-        mockMvc.perform(get("/api/v1/categories/{id}", 1L))
+        mockMvc.perform(get("/api/v1/categories/{id}", 1L)
+                        .with(user(mockUser)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("Electronics"))
                 .andExpect(jsonPath("$.color").value("#000000"));
@@ -171,12 +176,11 @@ class CategoryControllerTest {
     @Test
     @DisplayName("GET /api/v1/categories/{id} should return 404 when category does not exist")
     void findByIdShouldReturn404() throws Exception {
-        // Arrange
-        when(categoryService.findById(99L))
+        when(categoryService.findById(eq(99L), any(User.class)))
                 .thenThrow(new ResourceNotFoundException("Category not found with id: 99"));
 
-        // Act & Assert
-        mockMvc.perform(get("/api/v1/categories/{id}", 99L))
+        mockMvc.perform(get("/api/v1/categories/{id}", 99L)
+                        .with(user(mockUser)))
                 .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/dustin/fintrack/controller/v1/TransactionControllerTest.java
+++ b/src/test/java/com/dustin/fintrack/controller/v1/TransactionControllerTest.java
@@ -5,16 +5,17 @@ import com.dustin.fintrack.dto.v1.request.TransactionRequestDTO;
 import com.dustin.fintrack.dto.v1.response.DashboardResponseDTO;
 import com.dustin.fintrack.dto.v1.response.TransactionResponseDTO;
 import com.dustin.fintrack.model.TransactionType;
+import com.dustin.fintrack.model.User;
 import com.dustin.fintrack.service.JwtService;
 import com.dustin.fintrack.service.TransactionService;
 import com.dustin.fintrack.service.UserDetailsServiceImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -26,10 +27,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WithMockUser
 @WebMvcTest(TransactionController.class)
 public class TransactionControllerTest {
 
@@ -48,20 +49,30 @@ public class TransactionControllerTest {
     @MockitoBean
     private UserDetailsServiceImpl userDetailsService;
 
+    private User mockUser;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = new User();
+        mockUser.setId(1L);
+        mockUser.setEmail("test@test.com");
+        mockUser.setName("Test User");
+        mockUser.setPassword("password");
+    }
+
     @Test
     @DisplayName("Should return 200 OK and list of transactions")
     void listAllSuccess() throws Exception {
-        // Arrange
         TransactionResponseDTO response = new TransactionResponseDTO();
         response.setId(1L);
         response.setDescription("Salary");
         response.setAmount(new BigDecimal("5000.0"));
         response.setType(TransactionType.INCOME);
 
-        when(transactionService.listAll()).thenReturn(List.of(response));
+        when(transactionService.listAll(any(User.class))).thenReturn(List.of(response));
 
-        // Act & Assert
         mockMvc.perform(get("/api/v1/transactions")
+                        .with(user(mockUser))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.size()").value(1))
@@ -72,7 +83,6 @@ public class TransactionControllerTest {
     @Test
     @DisplayName("Should return 201 Created when transaction is valid")
     void createSuccess() throws Exception {
-        // Arrange
         TransactionRequestDTO request = new TransactionRequestDTO();
         request.setDescription("Valid Transaction");
         request.setAmount(new BigDecimal("100.0"));
@@ -84,11 +94,11 @@ public class TransactionControllerTest {
         response.setId(1L);
         response.setDescription("Valid Transaction");
 
-        when(transactionService.create(any(TransactionRequestDTO.class))).thenReturn(response);
+        when(transactionService.create(any(TransactionRequestDTO.class), any(User.class))).thenReturn(response);
 
-        // Act & Assert
         mockMvc.perform(post("/api/v1/transactions")
                         .with(csrf())
+                        .with(user(mockUser))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -99,14 +109,13 @@ public class TransactionControllerTest {
     @Test
     @DisplayName("Should return 400 Bad Request when amount is negative")
     void createFailureInvalidData() throws Exception {
-        // Arrange
         TransactionRequestDTO request = new TransactionRequestDTO();
         request.setDescription("");
         request.setAmount(new BigDecimal("-10.0"));
 
-        // Act & Assert
         mockMvc.perform(post("/api/v1/transactions")
                         .with(csrf())
+                        .with(user(mockUser))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
@@ -115,18 +124,17 @@ public class TransactionControllerTest {
     @Test
     @DisplayName("Should return 200 OK and Dashboard data")
     void getDashboardSuccess() throws Exception {
-        // Arrange
         DashboardResponseDTO dashboardResponse = new DashboardResponseDTO();
         dashboardResponse.setTotalIncome(new BigDecimal("1000.0"));
         dashboardResponse.setTotalExpense(new BigDecimal("400.0"));
         dashboardResponse.setBalance(new BigDecimal("600.0"));
         dashboardResponse.setTransactions(List.of());
 
-        when(transactionService.getDashboardData(any(LocalDateTime.class), any(LocalDateTime.class)))
+        when(transactionService.getDashboardData(any(LocalDateTime.class), any(LocalDateTime.class), any(User.class)))
                 .thenReturn(dashboardResponse);
 
-        // Act & Assert
         mockMvc.perform(get("/api/v1/transactions/dashboard")
+                        .with(user(mockUser))
                         .param("start", "2026-01-01T00:00:00")
                         .param("end", "2026-01-31T23:59:59")
                         .contentType(MediaType.APPLICATION_JSON))
@@ -139,8 +147,8 @@ public class TransactionControllerTest {
     @Test
     @DisplayName("Should return 400 Bad Request when date parameters are missing")
     void getDashboardMissingParams() throws Exception {
-        // Act & Assert
         mockMvc.perform(get("/api/v1/transactions/dashboard")
+                        .with(user(mockUser))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
     }
@@ -148,17 +156,16 @@ public class TransactionControllerTest {
     @Test
     @DisplayName("GET /api/v1/transactions/{id} should return 200 OK when transaction exists")
     void findByIdSuccess() throws Exception {
-        // Arrange
         TransactionResponseDTO response = new TransactionResponseDTO();
         response.setId(1L);
         response.setDescription("Shopping");
         response.setDueDay(10);
         response.setIsPaid(false);
 
-        when(transactionService.findById(1L)).thenReturn(response);
+        when(transactionService.findById(eq(1L), any(User.class))).thenReturn(response);
 
-        // Act & Assert
-        mockMvc.perform(get("/api/v1/transactions/{id}", 1L))
+        mockMvc.perform(get("/api/v1/transactions/{id}", 1L)
+                        .with(user(mockUser)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.description").value("Shopping"))
                 .andExpect(jsonPath("$.dueDay").value(10));
@@ -167,19 +174,17 @@ public class TransactionControllerTest {
     @Test
     @DisplayName("GET /api/v1/transactions/{id} should return 404 when transaction does not exist")
     void findByIdNotFound() throws Exception {
-        // Arrange
-        when(transactionService.findById(99L))
+        when(transactionService.findById(eq(99L), any(User.class)))
                 .thenThrow(new ResourceNotFoundException("Transaction not found with id 99"));
 
-        // Act & Assert
-        mockMvc.perform(get("/api/v1/transactions/{id}", 99L))
+        mockMvc.perform(get("/api/v1/transactions/{id}", 99L)
+                        .with(user(mockUser)))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     @DisplayName("PUT /api/v1/transactions/{id} should return 200 OK when transaction is updated")
     void updateSuccess() throws Exception {
-        // Arrange
         TransactionRequestDTO request = new TransactionRequestDTO();
         request.setDescription("Cinema Atualizado");
         request.setAmount(new BigDecimal("80.0"));
@@ -195,11 +200,11 @@ public class TransactionControllerTest {
         response.setDueDay(15);
         response.setIsPaid(true);
 
-        when(transactionService.update(eq(1L), any(TransactionRequestDTO.class))).thenReturn(response);
+        when(transactionService.update(eq(1L), any(TransactionRequestDTO.class), any(User.class))).thenReturn(response);
 
-        // Act & Assert
         mockMvc.perform(put("/api/v1/transactions/{id}", 1L)
                         .with(csrf())
+                        .with(user(mockUser))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -211,7 +216,6 @@ public class TransactionControllerTest {
     @Test
     @DisplayName("PUT /api/v1/transactions/{id} should return 404 when transaction does not exist")
     void updateNotFound() throws Exception {
-        // Arrange
         TransactionRequestDTO request = new TransactionRequestDTO();
         request.setDescription("Erro");
         request.setAmount(new BigDecimal("10.0"));
@@ -219,12 +223,12 @@ public class TransactionControllerTest {
         request.setType(TransactionType.EXPENSE);
         request.setCategoryId(1L);
 
-        when(transactionService.update(eq(99L), any(TransactionRequestDTO.class)))
+        when(transactionService.update(eq(99L), any(TransactionRequestDTO.class), any(User.class)))
                 .thenThrow(new ResourceNotFoundException("Transaction not found with id: 99"));
 
-        // Act & Assert
         mockMvc.perform(put("/api/v1/transactions/{id}", 99L)
                         .with(csrf())
+                        .with(user(mockUser))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound());
@@ -233,25 +237,23 @@ public class TransactionControllerTest {
     @Test
     @DisplayName("DELETE /api/v1/transactions/{id} should return 204 No Content")
     void deleteSuccess() throws Exception {
-        // Arrange
-        doNothing().when(transactionService).delete(1L);
+        doNothing().when(transactionService).delete(eq(1L), any(User.class));
 
-        // Act & Assert
         mockMvc.perform(delete("/api/v1/transactions/{id}", 1L)
-                        .with(csrf()))
+                        .with(csrf())
+                        .with(user(mockUser)))
                 .andExpect(status().isNoContent());
     }
 
     @Test
     @DisplayName("DELETE /api/v1/transactions/{id} should return 404 when transaction does not exist")
     void deleteNotFound() throws Exception {
-        // Arrange
         doThrow(new ResourceNotFoundException("Transaction not found with id: 99"))
-                .when(transactionService).delete(99L);
+                .when(transactionService).delete(eq(99L), any(User.class));
 
-        // Act & Assert
         mockMvc.perform(delete("/api/v1/transactions/{id}", 99L)
-                        .with(csrf()))
+                        .with(csrf())
+                        .with(user(mockUser)))
                 .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/dustin/fintrack/service/CategoryServiceTest.java
+++ b/src/test/java/com/dustin/fintrack/service/CategoryServiceTest.java
@@ -5,6 +5,7 @@ import com.dustin.fintrack.dto.v1.request.CategoryRequestDTO;
 import com.dustin.fintrack.dto.v1.response.CategoryResponseDTO;
 import com.dustin.fintrack.model.Category;
 import com.dustin.fintrack.model.CategoryType;
+import com.dustin.fintrack.model.User;
 import com.dustin.fintrack.repository.CategoryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,9 +34,14 @@ public class CategoryServiceTest {
 
     private Category category;
     private CategoryRequestDTO request;
+    private User user;
 
     @BeforeEach
     void setUp() {
+        user = new User();
+        user.setId(1L);
+        user.setEmail("test@test.com");
+
         category = new Category();
         category.setId(1L);
         category.setName("Electronics");
@@ -43,6 +49,7 @@ public class CategoryServiceTest {
         category.setDescription("Unity tests");
         category.setCategoryType(CategoryType.ESSENTIAL);
         category.setSpendingLimit(new BigDecimal("300000"));
+        category.setUser(user);
 
         request = new CategoryRequestDTO();
         request.setName("Electronics");
@@ -57,7 +64,7 @@ public class CategoryServiceTest {
     void shouldSaveCategory() {
         when(categoryRepository.save(any(Category.class))).thenReturn(category);
 
-        CategoryResponseDTO result = categoryService.create(request);
+        CategoryResponseDTO result = categoryService.create(request, user);
 
         assertNotNull(result);
         assertEquals("Electronics", result.getName());
@@ -67,9 +74,9 @@ public class CategoryServiceTest {
     @Test
     @DisplayName("Should list all categories as ResponseDTOs")
     void shouldListAllCategories() {
-        when(categoryRepository.findAll()).thenReturn(List.of(category));
+        when(categoryRepository.findAllByUser(user)).thenReturn(List.of(category));
 
-        List<CategoryResponseDTO> result = categoryService.listAll();
+        List<CategoryResponseDTO> result = categoryService.listAll(user);
 
         assertFalse(result.isEmpty());
         assertEquals(1, result.size());
@@ -86,10 +93,10 @@ public class CategoryServiceTest {
         requestToUpdate.setCategoryType(CategoryType.DISCRETIONARY);
         requestToUpdate.setSpendingLimit(new BigDecimal("500000"));
 
-        when(categoryRepository.findById(1L)).thenReturn(Optional.of(category));
+        when(categoryRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(category));
         when(categoryRepository.save(any(Category.class))).thenAnswer(i -> i.getArgument(0));
 
-        CategoryResponseDTO result = categoryService.update(1L, requestToUpdate);
+        CategoryResponseDTO result = categoryService.update(1L, requestToUpdate, user);
 
         assertNotNull(result);
         assertEquals("Novo Nome", result.getName());
@@ -103,36 +110,36 @@ public class CategoryServiceTest {
     @Test
     @DisplayName("Should throw ResourceNotFoundException when updating non-existent ID")
     void updateShouldThrowExceptionWhenIdDoesNotExist() {
-        when(categoryRepository.findById(99L)).thenReturn(Optional.empty());
+        when(categoryRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
 
-        assertThrows(ResourceNotFoundException.class, () -> categoryService.update(99L, request));
+        assertThrows(ResourceNotFoundException.class, () -> categoryService.update(99L, request, user));
         verify(categoryRepository, never()).save(any(Category.class));
     }
 
     @Test
     @DisplayName("Should delete category when ID exists")
     void deleteShouldSucceedWhenIdExists() {
-        when(categoryRepository.findById(1L)).thenReturn(Optional.of(category));
+        when(categoryRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(category));
 
-        assertDoesNotThrow(() -> categoryService.delete(1L));
+        assertDoesNotThrow(() -> categoryService.delete(1L, user));
         verify(categoryRepository, times(1)).deleteById(1L);
     }
 
     @Test
     @DisplayName("Should throw ResourceNotFoundException when deleting non-existent ID")
     void deleteShouldThrowExceptionWhenIdDoesNotExist() {
-        when(categoryRepository.findById(99L)).thenReturn(Optional.empty());
+        when(categoryRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
 
-        assertThrows(ResourceNotFoundException.class, () -> categoryService.delete(99L));
+        assertThrows(ResourceNotFoundException.class, () -> categoryService.delete(99L, user));
         verify(categoryRepository, never()).deleteById(any());
     }
 
     @Test
     @DisplayName("Should return CategoryResponseDTO when ID exists")
     void findByIdShouldReturnDtoWhenIdExists() {
-        when(categoryRepository.findById(1L)).thenReturn(Optional.of(category));
+        when(categoryRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(category));
 
-        CategoryResponseDTO result = categoryService.findById(1L);
+        CategoryResponseDTO result = categoryService.findById(1L, user);
 
         assertNotNull(result);
         assertEquals("Electronics", result.getName());
@@ -140,16 +147,16 @@ public class CategoryServiceTest {
         assertEquals("Unity tests DTO", result.getDescription());
         assertEquals(CategoryType.ESSENTIAL, result.getCategoryType());
         assertEquals(new BigDecimal("300000"), result.getSpendingLimit());
-        verify(categoryRepository, times(1)).findById(1L);
+        verify(categoryRepository, times(1)).findByIdAndUser(1L, user);
     }
 
     @Test
     @DisplayName("Should throw ResourceNotFoundException when ID does not exist")
     void findByIdShouldThrowExceptionWhenIdDoesNotExist() {
-        when(categoryRepository.findById(99L)).thenReturn(Optional.empty());
+        when(categoryRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
 
-        assertThrows(ResourceNotFoundException.class, () -> categoryService.findById(99L));
-        verify(categoryRepository, times(1)).findById(99L);
+        assertThrows(ResourceNotFoundException.class, () -> categoryService.findById(99L, user));
+        verify(categoryRepository, times(1)).findByIdAndUser(99L, user);
     }
 
     @Test
@@ -157,7 +164,7 @@ public class CategoryServiceTest {
     void shouldPersistNewCategoryFields() {
         when(categoryRepository.save(any(Category.class))).thenReturn(category);
 
-        CategoryResponseDTO result = categoryService.create(request);
+        CategoryResponseDTO result = categoryService.create(request, user);
 
         assertEquals(CategoryType.ESSENTIAL, result.getCategoryType());
         assertEquals(new BigDecimal("300000"), result.getSpendingLimit());

--- a/src/test/java/com/dustin/fintrack/service/TransactionServiceTest.java
+++ b/src/test/java/com/dustin/fintrack/service/TransactionServiceTest.java
@@ -7,6 +7,7 @@ import com.dustin.fintrack.dto.v1.response.DashboardResponseDTO;
 import com.dustin.fintrack.model.Category;
 import com.dustin.fintrack.model.Transaction;
 import com.dustin.fintrack.model.TransactionType;
+import com.dustin.fintrack.model.User;
 import com.dustin.fintrack.repository.CategoryRepository;
 import com.dustin.fintrack.repository.TransactionRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,7 +22,6 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -42,12 +42,18 @@ public class TransactionServiceTest {
     private TransactionRequestDTO requestDTO;
     private Transaction transaction;
     private Category category;
+    private User user;
 
     @BeforeEach
     void setUp() {
+        user = new User();
+        user.setId(1L);
+        user.setEmail("test@test.com");
+
         category = new Category();
         category.setId(1L);
         category.setName("Lazer");
+        category.setUser(user);
 
         requestDTO = new TransactionRequestDTO();
         requestDTO.setDescription("Cinema");
@@ -63,53 +69,54 @@ public class TransactionServiceTest {
         transaction.setDueDay(10);
         transaction.setIsPaid(false);
         transaction.setCategory(category);
+        transaction.setUser(user);
     }
 
     @Test
     @DisplayName("Should create transaction successfully")
     void createSuccess() {
-        when(categoryRepository.findById(1L)).thenReturn(Optional.of(category));
+        when(categoryRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(category));
         when(transactionRepository.save(any(Transaction.class))).thenReturn(transaction);
 
-        TransactionResponseDTO result = transactionService.create(requestDTO);
+        TransactionResponseDTO result = transactionService.create(requestDTO, user);
 
         assertNotNull(result);
         assertEquals("Cinema", result.getDescription());
-        verify(categoryRepository, times(1)).findById(1L);
+        verify(categoryRepository, times(1)).findByIdAndUser(1L, user);
         verify(transactionRepository, times(1)).save(any(Transaction.class));
     }
 
     @Test
     @DisplayName("Should throw ResourceNotFoundException when category not found")
     void createCategoryNotFound() {
-        when(categoryRepository.findById(1L)).thenReturn(Optional.empty());
+        when(categoryRepository.findByIdAndUser(1L, user)).thenReturn(Optional.empty());
 
-        assertThrows(ResourceNotFoundException.class, () -> transactionService.create(requestDTO));
+        assertThrows(ResourceNotFoundException.class, () -> transactionService.create(requestDTO, user));
         verify(transactionRepository, never()).save(any(Transaction.class));
     }
 
     @Test
     @DisplayName("Should return a list of TransactionResponseDTO")
     void listAllSuccess() {
-        when(transactionRepository.findAll()).thenReturn(List.of(transaction));
+        when(transactionRepository.findAllByUser(user)).thenReturn(List.of(transaction));
 
-        List<TransactionResponseDTO> result = transactionService.listAll();
+        List<TransactionResponseDTO> result = transactionService.listAll(user);
 
         assertNotNull(result);
         assertEquals(1, result.size());
         assertEquals("Cinema", result.get(0).getDescription());
-        verify(transactionRepository, times(1)).findAll();
+        verify(transactionRepository, times(1)).findAllByUser(user);
     }
 
     @Test
     @DisplayName("Should return an empty list when no transactions exist")
     void listAllEmpty() {
-        when(transactionRepository.findAll()).thenReturn(List.of());
+        when(transactionRepository.findAllByUser(user)).thenReturn(List.of());
 
-        List<TransactionResponseDTO> result = transactionService.listAll();
+        List<TransactionResponseDTO> result = transactionService.listAll(user);
 
         assertTrue(result.isEmpty());
-        verify(transactionRepository, times(1)).findAll();
+        verify(transactionRepository, times(1)).findAllByUser(user);
     }
 
     @Test
@@ -119,18 +126,20 @@ public class TransactionServiceTest {
         income.setAmount(new BigDecimal("100.0"));
         income.setType(TransactionType.INCOME);
         income.setCategory(category);
+        income.setUser(user);
 
         Transaction expense = new Transaction();
         expense.setAmount(new BigDecimal("40.0"));
         expense.setType(TransactionType.EXPENSE);
         expense.setCategory(category);
+        expense.setUser(user);
 
         LocalDateTime start = LocalDateTime.now().minusDays(30);
         LocalDateTime end = LocalDateTime.now();
 
-        when(transactionRepository.findByDateRange(any(), any())).thenReturn(List.of(income, expense));
+        when(transactionRepository.findByUserAndDateRange(any(), any(), any())).thenReturn(List.of(income, expense));
 
-        DashboardResponseDTO result = transactionService.getDashboardData(start, end);
+        DashboardResponseDTO result = transactionService.getDashboardData(start, end, user);
 
         assertEquals(0, new BigDecimal("100.0").compareTo(result.getTotalIncome()));
         assertEquals(0, new BigDecimal("40.0").compareTo(result.getTotalExpense()));
@@ -141,9 +150,9 @@ public class TransactionServiceTest {
     @Test
     @DisplayName("Should return zeroed totals when no transactions are found")
     void getDashboardDataEmpty() {
-        when(transactionRepository.findByDateRange(any(), any())).thenReturn(List.of());
+        when(transactionRepository.findByUserAndDateRange(any(), any(), any())).thenReturn(List.of());
 
-        DashboardResponseDTO result = transactionService.getDashboardData(LocalDateTime.now(), LocalDateTime.now());
+        DashboardResponseDTO result = transactionService.getDashboardData(LocalDateTime.now(), LocalDateTime.now(), user);
 
         assertEquals(BigDecimal.ZERO, result.getTotalIncome());
         assertEquals(BigDecimal.ZERO, result.getTotalExpense());
@@ -155,9 +164,9 @@ public class TransactionServiceTest {
     @DisplayName("Should persist dueDay and isPaid correctly")
     void shouldPersistNewTransactionFields() {
         when(transactionRepository.save(any(Transaction.class))).thenReturn(transaction);
-        when(categoryRepository.findById(any())).thenReturn(Optional.of(category));
+        when(categoryRepository.findByIdAndUser(any(), any())).thenReturn(Optional.of(category));
 
-        TransactionResponseDTO result = transactionService.create(requestDTO);
+        TransactionResponseDTO result = transactionService.create(requestDTO, user);
 
         assertEquals(10, result.getDueDay());
         assertFalse(result.getIsPaid());
@@ -166,23 +175,23 @@ public class TransactionServiceTest {
     @Test
     @DisplayName("Should return TransactionResponseDTO when ID exists")
     void findByIdSuccess() {
-    when(transactionRepository.findById(1L)).thenReturn(Optional.of(transaction));
+        when(transactionRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(transaction));
 
-    TransactionResponseDTO result = transactionService.findById(1L);
+        TransactionResponseDTO result = transactionService.findById(1L, user);
 
-    assertNotNull(result);
-    assertEquals("Cinema", result.getDescription());
-    assertEquals(10, result.getDueDay());
-    verify(transactionRepository, times(1)).findById(1L);
+        assertNotNull(result);
+        assertEquals("Cinema", result.getDescription());
+        assertEquals(10, result.getDueDay());
+        verify(transactionRepository, times(1)).findByIdAndUser(1L, user);
     }
 
     @Test
     @DisplayName("Should throw ResourceNotFoundException when transaction ID does not exist")
     void findByIdNotFound() {
-        when(transactionRepository.findById(99L)).thenReturn(Optional.empty());
+        when(transactionRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
 
-        assertThrows(ResourceNotFoundException.class, () -> transactionService.findById(99L));
-        verify(transactionRepository, times(1)).findById(99L);
+        assertThrows(ResourceNotFoundException.class, () -> transactionService.findById(99L, user));
+        verify(transactionRepository, times(1)).findByIdAndUser(99L, user);
     }
 
     @Test
@@ -193,11 +202,11 @@ public class TransactionServiceTest {
         requestDTO.setDueDay(15);
         requestDTO.setIsPaid(true);
 
-        when(transactionRepository.findById(1L)).thenReturn(Optional.of(transaction));
-        when(categoryRepository.findById(1L)).thenReturn(Optional.of(category));
+        when(transactionRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(transaction));
+        when(categoryRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(category));
         when(transactionRepository.save(any(Transaction.class))).thenAnswer(i -> i.getArgument(0));
 
-        TransactionResponseDTO result = transactionService.update(1L, requestDTO);
+        TransactionResponseDTO result = transactionService.update(1L, requestDTO, user);
 
         assertNotNull(result);
         verify(transactionRepository, times(1)).save(any(Transaction.class));
@@ -206,27 +215,27 @@ public class TransactionServiceTest {
     @Test
     @DisplayName("Should throw ResourceNotFoundException when updating non-existent transaction")
     void updateNotFound() {
-        when(transactionRepository.findById(99L)).thenReturn(Optional.empty());
+        when(transactionRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
 
-        assertThrows(ResourceNotFoundException.class, () -> transactionService.update(99L, requestDTO));
+        assertThrows(ResourceNotFoundException.class, () -> transactionService.update(99L, requestDTO, user));
         verify(transactionRepository, never()).save(any(Transaction.class));
     }
 
     @Test
     @DisplayName("Should delete transaction when ID exists (Positive)")
     void deleteSuccess() {
-        when(transactionRepository.findById(1L)).thenReturn(Optional.of(transaction));
+        when(transactionRepository.findByIdAndUser(1L, user)).thenReturn(Optional.of(transaction));
 
-        assertDoesNotThrow(() -> transactionService.delete(1L));
+        assertDoesNotThrow(() -> transactionService.delete(1L, user));
         verify(transactionRepository, times(1)).deleteById(1L);
     }
 
     @Test
     @DisplayName("Should throw ResourceNotFoundException when deleting non-existent transaction (Negative)")
     void deleteNotFound() {
-        when(transactionRepository.findById(99L)).thenReturn(Optional.empty());
+        when(transactionRepository.findByIdAndUser(99L, user)).thenReturn(Optional.empty());
 
-        assertThrows(ResourceNotFoundException.class, () -> transactionService.delete(99L));
+        assertThrows(ResourceNotFoundException.class, () -> transactionService.delete(99L, user));
         verify(transactionRepository, never()).deleteById(any());
     }
 }


### PR DESCRIPTION
## Summary

- Added `flyway-core` + `flyway-database-postgresql` dependencies to `pom.xml`
- Created V1–V5 migrations representing the full schema evolution (users → categories → transactions → refresh_tokens → user isolation)
- V6 seeds demo user `cordeiro.dustin00@gmail.com` with 17 pre-configured categories (9 Essential, 8 Discretionary) with CLP spending limits
- Replaced `ddl-auto=update/validate` with `ddl-auto=none` in both profiles — Flyway is now the sole schema authority
- `baseline-on-migrate=true` in dev profile for existing local databases

## Local setup note
Drop and recreate the local database before running to apply all migrations and seeds from scratch:
\`\`\`bash
docker-compose down -v && docker-compose up -d
\`\`\`

## Scope deviation
V6 seed (demo user + categories) added beyond the original issue scope, as requested by the developer.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)