### PR TITLE
feat: pagination and filtering for list endpoints (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The API uses **stateless JWT authentication**. All endpoints except `/api/v1/aut
 - [x] **Issue #17:** Input Validation Hardening.
 - [x] **Issue #18:** Data Audit (Created/Updated Timestamps).
 - [x] **Issue #19:** Structured Logging (JSON / GCP & AWS Ready).
-- [ ] **Issue #20:** Pagination & Filtering on List Endpoints.
+- [x] **Issue #20:** Pagination & Filtering on List Endpoints.
 - [ ] **Issue #21:** Dashboard Enrichment (Per-Category Analytics).
 
 ### 🚀 V4 — Deploy

--- a/src/main/java/com/dustin/fintrack/controller/v1/CategoryController.java
+++ b/src/main/java/com/dustin/fintrack/controller/v1/CategoryController.java
@@ -28,8 +28,10 @@ public class CategoryController {
     }
 
     @GetMapping
-    public ResponseEntity<List<CategoryResponseDTO>> listAll(@AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(categoryService.listAll(user));
+    public ResponseEntity<List<CategoryResponseDTO>> listAll(
+            @RequestParam(required = false) String name,
+            @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(categoryService.listAll(user, name));
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/dustin/fintrack/controller/v1/TransactionController.java
+++ b/src/main/java/com/dustin/fintrack/controller/v1/TransactionController.java
@@ -1,5 +1,6 @@
 package com.dustin.fintrack.controller.v1;
 
+import com.dustin.fintrack.dto.v1.request.TransactionFilterDTO;
 import com.dustin.fintrack.dto.v1.request.TransactionRequestDTO;
 import com.dustin.fintrack.dto.v1.response.DashboardResponseDTO;
 import com.dustin.fintrack.dto.v1.response.TransactionResponseDTO;
@@ -7,6 +8,10 @@ import com.dustin.fintrack.model.User;
 import com.dustin.fintrack.service.TransactionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +19,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/transactions")
@@ -31,8 +35,11 @@ public class TransactionController {
     }
 
     @GetMapping
-    public ResponseEntity<List<TransactionResponseDTO>> listAll(@AuthenticationPrincipal User user) {
-        return ResponseEntity.ok(transactionService.listAll(user));
+    public ResponseEntity<Page<TransactionResponseDTO>> listAll(
+            TransactionFilterDTO filter,
+            @PageableDefault(size = 20, sort = "date", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(transactionService.listAllPaged(filter, pageable, user));
     }
 
     @GetMapping("/dashboard")

--- a/src/main/java/com/dustin/fintrack/dto/v1/request/TransactionFilterDTO.java
+++ b/src/main/java/com/dustin/fintrack/dto/v1/request/TransactionFilterDTO.java
@@ -1,0 +1,23 @@
+package com.dustin.fintrack.dto.v1.request;
+
+import com.dustin.fintrack.model.TransactionType;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class TransactionFilterDTO {
+
+    private TransactionType type;
+    private Long categoryId;
+    private Boolean isPaid;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime startDate;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime endDate;
+}

--- a/src/main/java/com/dustin/fintrack/repository/CategoryRepository.java
+++ b/src/main/java/com/dustin/fintrack/repository/CategoryRepository.java
@@ -13,5 +13,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     List<Category> findAllByUser(User user);
 
+    List<Category> findAllByUserAndNameContainingIgnoreCase(User user, String name);
+
     Optional<Category> findByIdAndUser(Long id, User user);
 }

--- a/src/main/java/com/dustin/fintrack/repository/TransactionRepository.java
+++ b/src/main/java/com/dustin/fintrack/repository/TransactionRepository.java
@@ -3,6 +3,7 @@ package com.dustin.fintrack.repository;
 import com.dustin.fintrack.model.Transaction;
 import com.dustin.fintrack.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -12,7 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+public interface TransactionRepository extends JpaRepository<Transaction, Long>, JpaSpecificationExecutor<Transaction> {
 
     List<Transaction> findAllByUser(User user);
 

--- a/src/main/java/com/dustin/fintrack/service/CategoryService.java
+++ b/src/main/java/com/dustin/fintrack/service/CategoryService.java
@@ -35,11 +35,12 @@ public class CategoryService {
     }
 
     @Transactional(readOnly = true)
-    public List<CategoryResponseDTO> listAll(User user) {
-        return categoryRepository.findAllByUser(user)
-                .stream()
-                .map(CategoryResponseDTO::new)
-                .toList();
+    public List<CategoryResponseDTO> listAll(User user, String name) {
+        List<Category> categories = (name != null && !name.isBlank())
+                ? categoryRepository.findAllByUserAndNameContainingIgnoreCase(user, name)
+                : categoryRepository.findAllByUser(user);
+
+        return categories.stream().map(CategoryResponseDTO::new).toList();
     }
 
     @Transactional

--- a/src/main/java/com/dustin/fintrack/service/TransactionService.java
+++ b/src/main/java/com/dustin/fintrack/service/TransactionService.java
@@ -1,18 +1,24 @@
 package com.dustin.fintrack.service;
 
 import com.dustin.fintrack.controller.exception.ResourceNotFoundException;
+import com.dustin.fintrack.dto.v1.request.TransactionFilterDTO;
 import com.dustin.fintrack.dto.v1.request.TransactionRequestDTO;
 import com.dustin.fintrack.model.Category;
 import com.dustin.fintrack.model.Transaction;
 import com.dustin.fintrack.model.User;
 import com.dustin.fintrack.repository.TransactionRepository;
 import com.dustin.fintrack.repository.CategoryRepository;
+import jakarta.persistence.criteria.Predicate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.dustin.fintrack.dto.v1.response.DashboardResponseDTO;
 import com.dustin.fintrack.model.TransactionType;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -52,6 +58,37 @@ public class TransactionService {
                 .stream()
                 .map(TransactionResponseDTO::new)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public Page<TransactionResponseDTO> listAllPaged(TransactionFilterDTO filter, Pageable pageable, User user) {
+        Specification<Transaction> spec = buildSpecification(filter, user);
+        return transactionRepository.findAll(spec, pageable).map(TransactionResponseDTO::new);
+    }
+
+    private Specification<Transaction> buildSpecification(TransactionFilterDTO filter, User user) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            predicates.add(cb.equal(root.get("user"), user));
+
+            if (filter.getType() != null) {
+                predicates.add(cb.equal(root.get("type"), filter.getType()));
+            }
+            if (filter.getCategoryId() != null) {
+                predicates.add(cb.equal(root.get("category").get("id"), filter.getCategoryId()));
+            }
+            if (filter.getIsPaid() != null) {
+                predicates.add(cb.equal(root.get("isPaid"), filter.getIsPaid()));
+            }
+            if (filter.getStartDate() != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("date"), filter.getStartDate()));
+            }
+            if (filter.getEndDate() != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("date"), filter.getEndDate()));
+            }
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/dustin/fintrack/controller/v1/CategoryControllerTest.java
+++ b/src/test/java/com/dustin/fintrack/controller/v1/CategoryControllerTest.java
@@ -71,7 +71,7 @@ class CategoryControllerTest {
         request.setCategoryType(CategoryType.ESSENTIAL);
         request.setSpendingLimit(new BigDecimal("300000"));
 
-        CategoryResponseDTO response = new CategoryResponseDTO(1L, "Electronics", "#000000", null, CategoryType.ESSENTIAL, new BigDecimal("300000"));
+        CategoryResponseDTO response = new CategoryResponseDTO(1L, "Electronics", "#000000", null, CategoryType.ESSENTIAL, new BigDecimal("300000"), null, null);
 
         when(categoryService.create(any(CategoryRequestDTO.class), any(User.class))).thenReturn(response);
 
@@ -88,10 +88,24 @@ class CategoryControllerTest {
     @Test
     @DisplayName("GET /api/v1/categories should return 200 OK with list")
     void listAllShouldReturn200() throws Exception {
-        CategoryResponseDTO response = new CategoryResponseDTO(1L, "Electronics", "#000000", null, CategoryType.ESSENTIAL, new BigDecimal("300000"));
-        when(categoryService.listAll(any(User.class))).thenReturn(List.of(response));
+        CategoryResponseDTO response = new CategoryResponseDTO(1L, "Electronics", "#000000", null, CategoryType.ESSENTIAL, new BigDecimal("300000"), null, null);
+        when(categoryService.listAll(any(User.class), any())).thenReturn(List.of(response));
 
         mockMvc.perform(get("/api/v1/categories")
+                        .with(user(mockUser)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(1))
+                .andExpect(jsonPath("$[0].name").value("Electronics"));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/categories?name=Elec should return 200 OK filtered")
+    void listAllWithNameFilterShouldReturn200() throws Exception {
+        CategoryResponseDTO response = new CategoryResponseDTO(1L, "Electronics", "#000000", null, CategoryType.ESSENTIAL, new BigDecimal("300000"), null, null);
+        when(categoryService.listAll(any(User.class), eq("Elec"))).thenReturn(List.of(response));
+
+        mockMvc.perform(get("/api/v1/categories")
+                        .param("name", "Elec")
                         .with(user(mockUser)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.size()").value(1))
@@ -107,7 +121,7 @@ class CategoryControllerTest {
         request.setCategoryType(CategoryType.DISCRETIONARY);
         request.setSpendingLimit(new BigDecimal("300000"));
 
-        CategoryResponseDTO response = new CategoryResponseDTO(1L, "Lazer", "#000", null, CategoryType.DISCRETIONARY, new BigDecimal("300000"));
+        CategoryResponseDTO response = new CategoryResponseDTO(1L, "Lazer", "#000", null, CategoryType.DISCRETIONARY, new BigDecimal("300000"), null, null);
         when(categoryService.update(eq(1L), any(CategoryRequestDTO.class), any(User.class))).thenReturn(response);
 
         mockMvc.perform(put("/api/v1/categories/{id}", 1L)
@@ -163,7 +177,7 @@ class CategoryControllerTest {
     @Test
     @DisplayName("GET /api/v1/categories/{id} should return 200 OK when category exists")
     void findByIdShouldReturn200() throws Exception {
-        CategoryResponseDTO response = new CategoryResponseDTO(1L, "Electronics", "#000000", null, CategoryType.ESSENTIAL, new BigDecimal("300000"));
+        CategoryResponseDTO response = new CategoryResponseDTO(1L, "Electronics", "#000000", null, CategoryType.ESSENTIAL, new BigDecimal("300000"), null, null);
         when(categoryService.findById(eq(1L), any(User.class))).thenReturn(response);
 
         mockMvc.perform(get("/api/v1/categories/{id}", 1L)

--- a/src/test/java/com/dustin/fintrack/controller/v1/TransactionControllerTest.java
+++ b/src/test/java/com/dustin/fintrack/controller/v1/TransactionControllerTest.java
@@ -19,6 +19,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -61,7 +64,7 @@ public class TransactionControllerTest {
     }
 
     @Test
-    @DisplayName("Should return 200 OK and list of transactions")
+    @DisplayName("Should return 200 OK and paginated list of transactions")
     void listAllSuccess() throws Exception {
         TransactionResponseDTO response = new TransactionResponseDTO();
         response.setId(1L);
@@ -69,15 +72,36 @@ public class TransactionControllerTest {
         response.setAmount(new BigDecimal("5000.0"));
         response.setType(TransactionType.INCOME);
 
-        when(transactionService.listAll(any(User.class))).thenReturn(List.of(response));
+        Page<TransactionResponseDTO> page = new PageImpl<>(List.of(response));
+        when(transactionService.listAllPaged(any(), any(), any(User.class))).thenReturn(page);
 
         mockMvc.perform(get("/api/v1/transactions")
                         .with(user(mockUser))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.size()").value(1))
-                .andExpect(jsonPath("$[0].description").value("Salary"))
-                .andExpect(jsonPath("$[0].amount").value(5000.0));
+                .andExpect(jsonPath("$.content.size()").value(1))
+                .andExpect(jsonPath("$.content[0].description").value("Salary"))
+                .andExpect(jsonPath("$.content[0].amount").value(5000.0))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    @DisplayName("Should return 200 OK filtering by type EXPENSE")
+    void listAllWithTypeFilter() throws Exception {
+        TransactionResponseDTO response = new TransactionResponseDTO();
+        response.setId(2L);
+        response.setDescription("Market");
+        response.setType(TransactionType.EXPENSE);
+
+        Page<TransactionResponseDTO> page = new PageImpl<>(List.of(response));
+        when(transactionService.listAllPaged(any(), any(), any(User.class))).thenReturn(page);
+
+        mockMvc.perform(get("/api/v1/transactions")
+                        .with(user(mockUser))
+                        .param("type", "EXPENSE"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(1))
+                .andExpect(jsonPath("$.content[0].description").value("Market"));
     }
 
     @Test

--- a/src/test/java/com/dustin/fintrack/service/CategoryServiceTest.java
+++ b/src/test/java/com/dustin/fintrack/service/CategoryServiceTest.java
@@ -79,11 +79,24 @@ public class CategoryServiceTest {
     void shouldListAllCategories() {
         when(categoryRepository.findAllByUser(user)).thenReturn(List.of(category));
 
-        List<CategoryResponseDTO> result = categoryService.listAll(user);
+        List<CategoryResponseDTO> result = categoryService.listAll(user, null);
 
         assertFalse(result.isEmpty());
         assertEquals(1, result.size());
         assertEquals("Electronics", result.get(0).getName());
+    }
+
+    @Test
+    @DisplayName("Should filter categories by name")
+    void shouldFilterCategoriesByName() {
+        when(categoryRepository.findAllByUserAndNameContainingIgnoreCase(user, "Elec")).thenReturn(List.of(category));
+
+        List<CategoryResponseDTO> result = categoryService.listAll(user, "Elec");
+
+        assertEquals(1, result.size());
+        assertEquals("Electronics", result.get(0).getName());
+        verify(categoryRepository, times(1)).findAllByUserAndNameContainingIgnoreCase(user, "Elec");
+        verify(categoryRepository, never()).findAllByUser(any());
     }
 
     @Test

--- a/src/test/java/com/dustin/fintrack/service/TransactionServiceTest.java
+++ b/src/test/java/com/dustin/fintrack/service/TransactionServiceTest.java
@@ -1,6 +1,7 @@
 package com.dustin.fintrack.service;
 
 import com.dustin.fintrack.controller.exception.ResourceNotFoundException;
+import com.dustin.fintrack.dto.v1.request.TransactionFilterDTO;
 import com.dustin.fintrack.dto.v1.request.TransactionRequestDTO;
 import com.dustin.fintrack.dto.v1.response.TransactionResponseDTO;
 import com.dustin.fintrack.dto.v1.response.DashboardResponseDTO;
@@ -17,6 +18,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -239,5 +245,37 @@ public class TransactionServiceTest {
 
         assertThrows(ResourceNotFoundException.class, () -> transactionService.delete(99L, user));
         verify(transactionRepository, never()).deleteById(any());
+    }
+
+    @Test
+    @DisplayName("Should return paginated list with no filters applied")
+    void listAllPagedNoFilter() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Transaction> page = new PageImpl<>(List.of(transaction), pageable, 1);
+
+        when(transactionRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(page);
+
+        Page<TransactionResponseDTO> result = transactionService.listAllPaged(new TransactionFilterDTO(), pageable, user);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        assertEquals("Cinema", result.getContent().get(0).getDescription());
+        verify(transactionRepository, times(1)).findAll(any(Specification.class), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("Should return empty page when no transactions match filter")
+    void listAllPagedEmptyResult() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Transaction> emptyPage = Page.empty(pageable);
+
+        when(transactionRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(emptyPage);
+
+        TransactionFilterDTO filter = new TransactionFilterDTO();
+        filter.setType(TransactionType.INCOME);
+        Page<TransactionResponseDTO> result = transactionService.listAllPaged(filter, pageable, user);
+
+        assertTrue(result.isEmpty());
+        assertEquals(0, result.getTotalElements());
     }
 }


### PR DESCRIPTION
## Summary
- `GET /transactions` now returns `Page<TransactionResponseDTO>` with optional filters: `type`, `categoryId`, `isPaid`, `startDate`, `endDate`
- Default page size 20, sorted by `date DESC` — configurable via `?page=`, `?size=`, `?sort=`
- `GET /categories` gains optional `?name=` filter (case-insensitive contains search)
- Uses `JpaSpecificationExecutor` for dynamic query composition on transactions
- Added `TransactionFilterDTO` for clean filter binding from query params
- Updated all affected unit tests (service + controller layers)

## Test plan
- [ ] `GET /transactions` returns paginated JSON with `content`, `totalElements`, `totalPages`
- [ ] `GET /transactions?type=EXPENSE` filters correctly
- [ ] `GET /transactions?isPaid=true&page=0&size=5` pages and filters
- [ ] `GET /categories?name=laze` returns matching categories (case-insensitive)
- [ ] `GET /categories` without `name` returns all categories as before

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)