### PR TITLE
feat: per-category analytics on dashboard (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The API uses **stateless JWT authentication**. All endpoints except `/api/v1/aut
 - [x] **Issue #18:** Data Audit (Created/Updated Timestamps).
 - [x] **Issue #19:** Structured Logging (JSON / GCP & AWS Ready).
 - [x] **Issue #20:** Pagination & Filtering on List Endpoints.
-- [ ] **Issue #21:** Dashboard Enrichment (Per-Category Analytics).
+- [x] **Issue #21:** Dashboard Enrichment (Per-Category Analytics).
 
 ### 🚀 V4 — Deploy
 - [ ] **Issue #22:** Production Deploy on Railway.

--- a/src/main/java/com/dustin/fintrack/dto/v1/response/CategorySummaryDTO.java
+++ b/src/main/java/com/dustin/fintrack/dto/v1/response/CategorySummaryDTO.java
@@ -1,0 +1,18 @@
+package com.dustin.fintrack.dto.v1.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CategorySummaryDTO {
+    private Long categoryId;
+    private String categoryName;
+    private BigDecimal totalAmount;
+    private Long transactionCount;
+    private BigDecimal percentageOfTotal;
+}

--- a/src/main/java/com/dustin/fintrack/dto/v1/response/DashboardResponseDTO.java
+++ b/src/main/java/com/dustin/fintrack/dto/v1/response/DashboardResponseDTO.java
@@ -16,4 +16,6 @@ public class DashboardResponseDTO {
     private BigDecimal balance;
 
     private List<TransactionResponseDTO> transactions;
+    private List<CategorySummaryDTO> expensesByCategory;
+    private List<CategorySummaryDTO> incomeByCategory;
 }

--- a/src/main/java/com/dustin/fintrack/service/TransactionService.java
+++ b/src/main/java/com/dustin/fintrack/service/TransactionService.java
@@ -15,11 +15,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.dustin.fintrack.dto.v1.response.CategorySummaryDTO;
 import com.dustin.fintrack.dto.v1.response.DashboardResponseDTO;
 import com.dustin.fintrack.model.TransactionType;
 
+import java.math.RoundingMode;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.math.BigDecimal;
@@ -111,7 +115,38 @@ public class TransactionService {
                 .map(TransactionResponseDTO::new)
                 .collect(Collectors.toList());
 
-        return new DashboardResponseDTO(totalIncome, totalExpense, balance, transactionDTOs);
+        List<CategorySummaryDTO> expensesByCategory = buildCategorySummaries(
+                transactions, TransactionType.EXPENSE, totalExpense);
+
+        List<CategorySummaryDTO> incomeByCategory = buildCategorySummaries(
+                transactions, TransactionType.INCOME, totalIncome);
+
+        return new DashboardResponseDTO(totalIncome, totalExpense, balance, transactionDTOs,
+                expensesByCategory, incomeByCategory);
+    }
+
+    private List<CategorySummaryDTO> buildCategorySummaries(
+            List<Transaction> transactions, TransactionType type, BigDecimal total) {
+
+        Map<Long, List<Transaction>> grouped = transactions.stream()
+                .filter(t -> t.getType() == type)
+                .collect(Collectors.groupingBy(t -> t.getCategory().getId()));
+
+        return grouped.entrySet().stream().map(entry -> {
+            List<Transaction> group = entry.getValue();
+            String categoryName = group.get(0).getCategory().getName();
+            BigDecimal groupTotal = group.stream()
+                    .map(Transaction::getAmount)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+            long count = group.size();
+            BigDecimal percentage = total.compareTo(BigDecimal.ZERO) == 0
+                    ? BigDecimal.ZERO
+                    : groupTotal.multiply(new BigDecimal("100"))
+                            .divide(total, 2, RoundingMode.HALF_UP);
+
+            return new CategorySummaryDTO(entry.getKey(), categoryName, groupTotal, count, percentage);
+        }).sorted(Comparator.comparing(CategorySummaryDTO::getTotalAmount).reversed())
+                .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/dustin/fintrack/controller/v1/TransactionControllerTest.java
+++ b/src/test/java/com/dustin/fintrack/controller/v1/TransactionControllerTest.java
@@ -153,6 +153,8 @@ public class TransactionControllerTest {
         dashboardResponse.setTotalExpense(new BigDecimal("400.0"));
         dashboardResponse.setBalance(new BigDecimal("600.0"));
         dashboardResponse.setTransactions(List.of());
+        dashboardResponse.setExpensesByCategory(List.of());
+        dashboardResponse.setIncomeByCategory(List.of());
 
         when(transactionService.getDashboardData(any(LocalDateTime.class), any(LocalDateTime.class), any(User.class)))
                 .thenReturn(dashboardResponse);

--- a/src/test/java/com/dustin/fintrack/service/TransactionServiceTest.java
+++ b/src/test/java/com/dustin/fintrack/service/TransactionServiceTest.java
@@ -153,6 +153,10 @@ public class TransactionServiceTest {
         assertEquals(0, new BigDecimal("40.0").compareTo(result.getTotalExpense()));
         assertEquals(0, new BigDecimal("60.0").compareTo(result.getBalance()));
         assertEquals(2, result.getTransactions().size());
+        assertEquals(1, result.getExpensesByCategory().size());
+        assertEquals(1, result.getIncomeByCategory().size());
+        assertEquals("Lazer", result.getExpensesByCategory().get(0).getCategoryName());
+        assertEquals(0, new BigDecimal("100.00").compareTo(result.getIncomeByCategory().get(0).getPercentageOfTotal()));
     }
 
     @Test
@@ -166,6 +170,8 @@ public class TransactionServiceTest {
         assertEquals(BigDecimal.ZERO, result.getTotalExpense());
         assertEquals(BigDecimal.ZERO, result.getBalance());
         assertTrue(result.getTransactions().isEmpty());
+        assertTrue(result.getExpensesByCategory().isEmpty());
+        assertTrue(result.getIncomeByCategory().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `GET /transactions/dashboard` now returns `expensesByCategory` and `incomeByCategory` alongside existing totals
- Each `CategorySummaryDTO` contains: `categoryId`, `categoryName`, `totalAmount`, `transactionCount`, `percentageOfTotal`
- Computed in-memory from already-loaded transactions — zero additional DB queries
- Sorted by `totalAmount DESC` for quick visual scanning
- Added `CategorySummaryDTO` response DTO

## Test plan
- [ ] Dashboard response includes `expensesByCategory` and `incomeByCategory` arrays
- [ ] Each category entry shows correct `totalAmount` and `percentageOfTotal`
- [ ] Empty period returns empty arrays (not null)
- [ ] Percentage sums to 100% when single category covers entire type

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)